### PR TITLE
Add Barrier

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -379,6 +379,22 @@ core.register_node(":ignore", {
 		return ""
 	end,
 })
+--Stvk pr here
+minetest.register_node(":barrier", {
+	description = S("Barrier"),
+	inventory_image =ignore.png^air.png",
+	wield_image = "ignore.png^air.png",
+	drawtype = "airlike",
+	paramtype = "light",
+	sunlight_propagates = true,
+        walkable = true,
+	pointable = false,
+	diggable = false
+	buildable_to = true,
+        floodable: false,
+	drop = "",
+	groups = {not_in_creative_inventory = 1},
+})
 
 -- The hand (bare definition)
 core.register_item(":", {


### PR DESCRIPTION
Barrier like air but walkable

Add compact, short information about your PR for easier understanding:

add a new block: Barrier
like air but walkable

- Goal of the PR 
Add a barrier block for map and content creators
- How does the PR work?
i copied apple marker code and edit a bit
its work like air but walkable
- Does it resolve any reported issue?
no, i did not check feature request yet
- Does this relate to a goal in [the roadmap](../doc/direction.md)?
no
- If not a bug fix, why is this PR needed? What usecases does it solve?
useful for map creator and conten creator

## To do

Ready for Review.
<!-- ^ delete one -->

- [ ] List
- [ ] Things
- [ ] To do
probally make a new texture

## How to test
/giveme barrier
<!-- Example code or instructions -->
